### PR TITLE
Fix a TypeScript error in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,8 +10,8 @@
     "lib": ["es5", "dom"],
     "strictNullChecks": false,
     "baseUrl": "./src",
-    "paths": [
-    ],
+    "paths": {
+    },
     "types": [
       "core-js",
       "node"


### PR DESCRIPTION
`paths` should be an object not an array. Inside the object literal, each member key defines a path lookup pattern, and the value is the string array that shows all the paths globs to look in when TypeScript is looking for that pattern.

Imagine it something like:

```
interface Paths {
    [key : string]: string[]
}
```

A real sample from [TypeScript documentation](https://github.com/Microsoft/TypeScript/wiki/What%27s-new-in-TypeScript#path-mapping):

```
{
  "compilerOptions": {
    "paths": {
      "jquery": ["node_modules/jquery/dist/jquery.d.ts"]
    }
}
```