### PR TITLE
#12 Fix "host" & add "https" to webpack-dev-server

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -33,7 +33,8 @@ function webpackConfig(options: EnvOptions = {}): WebpackConfig {
     ENV: JSON.stringify(options.ENV),
     HMR: options.HMR,
     PORT: 3000,
-    HOST: 'localhost'
+    HOST: 'localhost',
+    HTTPS: false
   };
 
   return {
@@ -123,7 +124,9 @@ function webpackConfig(options: EnvOptions = {}): WebpackConfig {
       port: CONSTANTS.PORT,
       hot: CONSTANTS.HMR,
       inline: CONSTANTS.HMR,
-      historyApiFallback: true
+      historyApiFallback: true,
+      host: CONSTANTS.HOST,
+      https: CONSTANTS.HTTPS
     },
 
     node: {
@@ -176,6 +179,8 @@ interface WebpackConfig {
     historyApiFallback?: boolean;
     hot?: boolean;
     inline?: boolean;
+    host?: string;
+    https?: boolean;
   };
   node?: {
     process?: boolean;


### PR DESCRIPTION
The "host" argument was in constants but not used. This is reported in #12.

While at it, I discovered this while trying something with HTTPS, so I added that to the config too.