### PR TITLE
Cannot find module 'assets-webpack-plugin'

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "@types/core-js": "^0.9.28",
     "@types/node": "^4.0.30",
+    "assets-webpack-plugin": "^3.4.0",
     "awesome-typescript-loader": "^2.2.1",
     "cross-spawn": "^4.0.0",
     "es6-promise": "^3.1.2",


### PR DESCRIPTION
New install on both Linux/Windows builds fail due to the missing devDependency `assets-webpack-plugin`.